### PR TITLE
Fix docblock typo

### DIFF
--- a/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -19,7 +19,7 @@
  */
 
 /**
- * This sniff checks for propper variable naming.
+ * This sniff checks for proper variable naming.
  *
  * All variables must be camel-cased and *should* not contain numbers.
  *


### PR DESCRIPTION
## Summary
- fix typo in ValidVariableNameSniff docblock

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d92e9e320832fb78387dcc240ac53