### PR TITLE
Fix undefined vars in naming convention sniff

### DIFF
--- a/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -51,8 +51,9 @@ class ZFCS_Sniffs_NamingConventions_ValidVariableNameSniff
      */
     protected function processVariable(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        $tokens  = $phpcsFile->getTokens();
-        $varName = ltrim($tokens[$stackPtr]['content'], '$');
+        $tokens          = $phpcsFile->getTokens();
+        $varName         = ltrim($tokens[$stackPtr]['content'], '$');
+        $originalVarName = $varName;
 
         $phpReservedVars = array(
             '_SERVER',
@@ -117,8 +118,14 @@ class ZFCS_Sniffs_NamingConventions_ValidVariableNameSniff
      */
     protected function processMemberVar(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        $tokens  = $phpcsFile->getTokens();
-        $varName = ltrim($tokens[$stackPtr]['content'], '$');
+        $tokens          = $phpcsFile->getTokens();
+        $varName         = ltrim($tokens[$stackPtr]['content'], '$');
+        $memberProps     = $phpcsFile->getMemberProperties($stackPtr);
+        $public          = true;
+
+        if (isset($memberProps['scope']) === true && $memberProps['scope'] === 'private') {
+            $public = false;
+        }
 
         if (PHP_CodeSniffer::isCamelCaps($varName, false, $public, false) === false) {
             $error = 'Variable "%s" is not in valid camel caps format';
@@ -141,7 +148,8 @@ class ZFCS_Sniffs_NamingConventions_ValidVariableNameSniff
      */
     protected function processVariableInString(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        $tokens = $phpcsFile->getTokens();
+        $tokens          = $phpcsFile->getTokens();
+        $originalVarName = $tokens[$stackPtr]['content'];
 
         $phpReservedVars = array(
             '_SERVER',


### PR DESCRIPTION
## Summary
- define `$originalVarName` in variable naming sniff
- ensure visibility check uses `$public` flag for member variables

## Testing
- `phpunit` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d804406c0832f9a2f6ef495b02b04