### PR TITLE
Fix minor grammar in README

### DIFF
--- a/README
+++ b/README
@@ -1,18 +1,18 @@
 This is the PHPCS sniff for the Zend Framework 2 coding standard.
 
-It is currently not complete yet, as a few sniffs are still missing.
+It is not yet complete, as a few sniffs are still missing.
 
 DONE:
 
 - Check for proper function call argument style
-- Check for function braces being on a line by themself
-- Check for invalid usage for short open tags
+- Check for function braces being on a line by themselves
+- Check for invalid usage of short open tags
 - Check for valid indentation
 - Check for character limit (80 soft, 120 hard)
-- Check for valid unix line-endings
+- Check for valid Unix line-endings
 - Check for valid variable names
-- Check for invalid usage of closing PHP tag
-- Check for invalid usage of perl-style hash comments
+- Check for invalid usage of the closing PHP tag
+- Check for invalid usage of Perl-style hash comments
 
 TODO:
 
@@ -20,7 +20,7 @@ TODO:
 - Check for valid interface naming
 - Check for valid class/method naming
 - Check for valid constant naming
-- Check for proper user of string literals
+- Check for proper use of string literals
 - Check for proper array styles
 - Check for proper class/method documentation blocks
 - Check for invalid use of 'var' keyword


### PR DESCRIPTION
## Summary
- fix minor grammatical issues in the README

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d948fa548832f8a6ad142a170fdcc